### PR TITLE
added reconciler manager/cache-ing util

### DIFF
--- a/python/util/__init__.py
+++ b/python/util/__init__.py
@@ -12,3 +12,4 @@ from .files import get_client_file_details, get_depot_file_details, sync_publish
 from .files import client_to_depot_paths, depot_to_client_paths, P4InvalidFileNameException
 from .change import create_change, add_to_change, find_change_containing, submit_change, get_change_details
 from .url import url_from_depot_path, depot_path_from_url
+from .reconcile import recursive_reconcile

--- a/python/util/reconcile.py
+++ b/python/util/reconcile.py
@@ -1,0 +1,114 @@
+# Copyright (c) 2013 Shotgun Software Inc.
+#
+# CONFIDENTIAL AND PROPRIETARY
+#
+# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit
+# Source Code License included in this distribution package. See LICENSE.
+# By accessing, using, copying or modifying this work you indicate your
+# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
+# not expressly granted therein are reserved by Shotgun Software Inc.
+
+"""
+Common utilities for reconciling the state of Perforce files
+"""
+
+import os
+import re
+
+from P4 import P4Exception, Map as P4Map  # Prefix P4 for consistency
+
+import sgtk
+from sgtk import TankError
+from tank_vendor import six
+from tank_vendor.six.moves import urllib
+
+logger = sgtk.LogManager.get_logger(__name__)
+
+
+class P4Reconciler:
+    _root_path = None
+    _p4 = None
+    actions = {}
+
+    def __init__(self, p4, root_path):
+        """
+        Object to handle scanning directories for statuses, then keeping it cached
+        to individually reconcile the discovered paths as needed.
+
+        :param p4: perforce connection
+        :param root_path: base path to scan from
+        """
+        self.p4 = p4
+        self.root_path = root_path
+
+
+    def __getattr__(self, item):
+        avail_actions = ['add', "edit", "delete"]
+        avail_action_info_list = ["{}_info".format(i) for i in avail_actions]
+        avail_action_file_list = ["{}_files".format(i) for i in avail_actions]
+        actions =  self.__dict__.get('actions')
+        if item in avail_action_info_list:
+            return actions.get(item.split('_')[0])
+        elif item in avail_action_file_list:
+            return [i.get('clientFile') for i in actions.get(item.split('_')[0])]
+        else:
+            raise AttributeError("Attribute '{}' not does not exist. If you are attempting"\
+            "to get reconcile states, please use any of {} for details of each, or {} for a list of"\
+            " paths for each.".format(item, avail_action_info_list, avail_action_file_list))
+
+    @property
+    def p4(self):
+        return self._p4
+
+    @p4.setter
+    def p4(self, value):
+        self._p4 = value
+
+    @property
+    def root_path(self):
+        return self._root_path
+
+    @root_path.setter
+    def root_path(self, value):
+        self._root_path = value
+
+    def reset_collection(self):
+        self.actions = {
+            "add" : [],
+            "edit": [],
+            "delete": []
+        }
+
+    def recursive_scan(self, path=None):
+        """
+        Scan the chosen directory recursively, reconcile status of
+        local file state against Perforce server. 
+        Added files: File locally that doesnt exist in the depot. 
+        Edited files: Files locally that have different contents than the depot files
+        Deleted files: Files the arent local but expected to be by the latest depot workspace expectation.
+        """
+        self.reset_collection()
+
+        if path:
+            self.root_path = path
+
+        logger.debug("Starting the reconcile scan....")
+        for root, dirs, files in os.walk(self.root_path):
+
+            response = self.p4.run('reconcile', "-n", os.path.join(root, "*"))
+            if response:
+                
+                for item in response:
+                    if type(item)==dict:
+                        action = item.get('action')
+                        if action:
+                            self.actions.get(action).append(item)
+
+
+def recursive_reconcile(path):
+    fw = sgtk.platform.current_bundle()
+    p4 = fw.connection.connect()
+
+    reconciler = P4Reconciler(p4, path)
+    reconciler.recursive_scan()
+    return reconciler


### PR DESCRIPTION
- reconciler utility to reconcile a directory recursively and return information regarding the state of local files against what perforce is expecting

usage:
```python
p4_reconciler = fw.util.recursive_reconcile(<path>)
```
Then, utilize the reconciler object to get the cached information from the reconcile against p4.
```python
# return list of files being added
p4_reconciler.add_files 

# return list of dictionaries of reconcile info for the action type
p4_reconciler.add_info

# this can be done for deletes and edits as well
p4_reconciler.delete_info
p4_reconciler.edit_info

p4_reconciler.delete_files
p4_reconciler.edit_files
```

You can rerun another recursive reconcile with the same object...
```python
p4_reconciler.recursive_scan(path)
```
---
`Edited 2021.10.19 for correcting framework name`